### PR TITLE
remove `--flake8` from `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 	# use this to run tests
 	rm -rf _ckpt_*
 	rm -rf ./lightning_logs
-	python -m coverage run --source src/lightning_utilities -m pytest src/lightning_utilities tests -v --flake8
+	python -m coverage run --source src/lightning_utilities -m pytest src/lightning_utilities tests -v
 	python -m coverage report
 
 	# specific file


### PR DESCRIPTION
For now, `make test` produces the error as followings:

ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...] __main__.py: error: unrecognized arguments: --flake8

Removing `--flake8` can fix the error, just as with https://github.com/Lightning-AI/lightning/blob/master/Makefile#L39

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 😄 
