### PR TITLE
Add method to lazily import modules

### DIFF
--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -141,13 +141,12 @@ class LazyModule(ModuleType):
 
     Args:
         module_name: the fully-qualified module name to import
-        callback (None): a callback function to call before importing the
-            module
+        callback: a callback function to call before importing the module
     """
 
     def __init__(self, module_name: str, callback: Optional[Callable] = None) -> None:
         super().__init__(module_name)
-        self._module: module = None
+        self._module: Any = None
         self._callback = callback
 
     def __getattr__(self, item: str) -> Any:
@@ -185,8 +184,7 @@ def lazy_import(module_name: str, callback: Optional[Callable] = None) -> LazyMo
         tf.__version__
     Args:
         module_name: the fully-qualified module name to import
-        callback (None): a callback function to call before importing the
-            module
+        callback: a callback function to call before importing the module
     Returns:
         a proxy module object that will be lazily imported when first used
     """

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -147,7 +147,7 @@ class LazyModule(ModuleType):
 
     def __init__(self, module_name: str, callback: Optional[Callable] = None) -> None:
         super().__init__(module_name)
-        self._module = None
+        self._module: module = None
         self._callback = callback
 
     def __getattr__(self, item: str) -> Any:
@@ -168,12 +168,11 @@ class LazyModule(ModuleType):
             self._callback()
 
         # Actually import the module
-        module = importlib.import_module(self.__name__)
-        self._module = module
+        self._module = importlib.import_module(self.__name__)
 
         # Update this object's dict so that attribute references are efficient
         # (__getattr__ is only called on lookups that fail)
-        self.__dict__.update(module.__dict__)
+        self.__dict__.update(self._module.__dict__)
 
 
 def lazy_import(module_name: str, callback: Optional[Callable] = None) -> LazyModule:

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -1,12 +1,13 @@
 # Copyright The PyTorch Lightning team.
 # Licensed under the Apache License, Version 2.0 (the "License");
 #     http://www.apache.org/licenses/LICENSE-2.0
+
 import importlib
 import operator
 from functools import lru_cache
 from importlib.util import find_spec
-import types
-from typing import Any, Callable, List
+from types import ModuleType
+from typing import Any, Callable, List, Optional
 
 import pkg_resources
 from packaging.requirements import Requirement
@@ -135,16 +136,16 @@ def get_dependency_min_version_spec(package_name: str, dependency_name: str) -> 
     )
 
 
-class LazyModule(types.ModuleType):
-    """Proxy module that lazily imports the underlying module the first time it
-    is actually used.
+class LazyModule(ModuleType):
+    """Proxy module that lazily imports the underlying module the first time it is actually used.
+
     Args:
         module_name: the fully-qualified module name to import
         callback (None): a callback function to call before importing the
             module
     """
 
-    def __init__(self, module_name: str, callback: Callable = None) -> None:
+    def __init__(self, module_name: str, callback: Optional[Callable] = None) -> None:
         super().__init__(module_name)
         self._module = None
         self._callback = callback
@@ -175,10 +176,9 @@ class LazyModule(types.ModuleType):
         self.__dict__.update(module.__dict__)
 
 
-def lazy_import(module_name: str, callback: Callable = None) -> LazyModule:
-    """Returns a proxy module object that will lazily import the given module
-    the first time it is used.
-    Example usage::
+def lazy_import(module_name: str, callback: Optional[Callable] = None) -> LazyModule:
+    """Returns a proxy module object that will lazily import the given module the first time it is used. Example usage::
+
         # Lazy version of `import tensorflow as tf`
         tf = lazy_import("tensorflow")
         # Other commands

--- a/tests/unittests/core/test_imports.py
+++ b/tests/unittests/core/test_imports.py
@@ -8,6 +8,7 @@ from lightning_utilities.core.imports import (
     get_dependency_min_version_spec,
     module_available,
     RequirementCache,
+    lazy_import,
 )
 
 try:
@@ -63,3 +64,17 @@ def test_get_dependency_min_version_spec():
 
     with pytest.raises(PackageNotFoundError, match="invalid"):
         get_dependency_min_version_spec("invalid", "invalid")
+
+def test_lazy_import():
+
+    def callback_fcn():
+        raise ValueError
+
+    with pytest.raises(ValueError):
+        math = lazy_import("math", callback=callback_fcn)
+        math.floor(5.1)
+    with pytest.raises(ModuleNotFoundError):
+        module = lazy_import("asdf")
+        print(module)
+    os = lazy_import("os")
+    assert os.getcwd()

--- a/tests/unittests/core/test_imports.py
+++ b/tests/unittests/core/test_imports.py
@@ -6,9 +6,9 @@ import pytest
 from lightning_utilities.core.imports import (
     compare_version,
     get_dependency_min_version_spec,
+    lazy_import,
     module_available,
     RequirementCache,
-    lazy_import,
 )
 
 try:
@@ -65,8 +65,8 @@ def test_get_dependency_min_version_spec():
     with pytest.raises(PackageNotFoundError, match="invalid"):
         get_dependency_min_version_spec("invalid", "invalid")
 
-def test_lazy_import():
 
+def test_lazy_import():
     def callback_fcn():
         raise ValueError
 


### PR DESCRIPTION
# Before submitting



- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [X] Did you write any new necessary tests?

## What does this PR do?

This PR adds the ability to lazily import modules so that they are not actually imported until their first reference

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
