### PR TITLE
Allow frozen dataclasses in `apply_to_collection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Allow frozen dataclasses in `apply_to_collection` ([#98](https://github.com/Lightning-AI/utilities/pull/98))
 
 
 ### Changed

--- a/tests/unittests/core/test_apply_func.py
+++ b/tests/unittests/core/test_apply_func.py
@@ -324,3 +324,13 @@ def test_apply_to_collection_frozen_dataclass():
     foo = Foo(0)
     with pytest.raises(ValueError, match="frozen dataclass was passed"):
         apply_to_collection(foo, int, lambda x: x + 1)
+
+
+def test_apply_to_collection_allow_frozen_dataclass():
+    @dataclasses.dataclass(frozen=True)
+    class Foo:
+        input: int
+
+    foo = Foo(0)
+    result = apply_to_collection(foo, int, lambda x: x + 1, allow_frozen=True)
+    assert foo == result


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
  Docstring, yes.
- [ ] Did all existing and newly added tests pass locally?
  No, some tests were broken even without my changes. However, all tests in [`test_apply_func.py`](https://github.com/Lightning-AI/utilities/blob/d8f0b17e9ce64ec81caa514b3cd9d5301414c13a/tests/unittests/core/test_apply_func.py), including my new one, passed.

</details>

## What does this PR do?

Allow frozen dataclasses to be ignored in `apply_to_collection`. This is useful to allow ignoring values which we never cared about anyway, [for example when using `apply_to_collection` to move data to a device](https://github.com/Lightning-AI/lightning/blob/1b1241ceb12fce0e30b4eb8bdb54779995a42e0a/src/lightning/fabric/utilities/optimizer.py#L34).
This (combined with a change in the previously linked line, see [main repo PR](https://github.com/Lightning-AI/lightning/pull/16656)) allows saving optimizers for which the `state` includes frozen dataclasses that we just want to pass through.

Should be completely backward-compatible since I introduce a new keyword argument for this.