### PR TITLE
fix: Add `py.typed` to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CHANGELOG.md
+include src/lightning_utilities/py.typed
 graft src/lightning_utilities/test
 graft requirements
 prune src/lightning_utilities/cli


### PR DESCRIPTION
The `py.typed` file was added but did not become part of the distribution.

Fixes #15889

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes #15889 (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
