### PR TITLE
ci: remove duplicate try to publish

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -56,7 +56,6 @@ jobs:
       run: ls -lh dist/
 
     - name: Upload to release
-      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
       uses: AButler/upload-release-assets@v2.0
       with:
         files: 'dist/*'
@@ -65,7 +64,7 @@ jobs:
 
   delay-publish:
     needs: build-package
-    if: startsWith(github.event.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
     - name: Delay ⏰ releasing
@@ -93,7 +92,6 @@ jobs:
 
     # We do this, since failures on test.pypi aren't that bad
     - name: Publish to Test PyPI
-      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         user: __token__
@@ -102,7 +100,6 @@ jobs:
         verbose: true
 
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         user: __token__


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

the trigger is tag and release so we upload only on release but the publish was passing on both event...
- https://github.com/Lightning-AI/utilities/actions/runs/4248017982
![image](https://user-images.githubusercontent.com/6035284/220895394-9a722217-5784-4d0d-86e1-b4037895aae2.png)
- https://github.com/Lightning-AI/utilities/actions/runs/4248017979 
![image](https://user-images.githubusercontent.com/6035284/220895550-f0d6703e-8b9f-4312-84b8-f299390017b8.png)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
