### PR TITLE
Adds undeclared dependency on setuptools

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 importlib-metadata >=4.0.0; python_version < '3.8'
 packaging >=17.1
+setuptools
 typing_extensions


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

Fixes the undeclared dependency on setuptools. There is an undeclared dependency on setuptools here https://github.com/Lightning-AI/utilities/blob/84cafbcdac24431820ff1c22c9699b84b088fad5/src/lightning_utilities/core/imports.py#L14

While it is true that most python environments will have setuptools pre-installed, this is not always safe to assume.

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.
