### PR TITLE
ci: enable setting python version for package build

### DIFF
--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version || '3.x' }}
 
       - name: Pull reusable 🤖 actions️
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
       - name: Set up Python 🐍 ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version || '3.x' }}
 
       - name: Pull reusable 🤖 actions️
         uses: actions/checkout@v4

--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -31,7 +31,7 @@ on:
         required: false
         default: ""
       build-matrix:
-        description: "what building configs in json format"
+        description: "what building configs in json format, expected keys are `os` and `python-version`"
         required: false
         type: string
         default: |
@@ -39,7 +39,7 @@ on:
             "os": ["ubuntu-latest"],
           }
       testing-matrix:
-        description: "what test configs to run in json format"
+        description: "what test configs to run in json format, expected keys are `os` and `python-version`"
         required: false
         type: string
         # default operating systems should be pinned to specific versions instead of "-latest" for stability

--- a/.github/workflows/ci-use-checks.yaml
+++ b/.github/workflows/ci-use-checks.yaml
@@ -44,6 +44,11 @@ jobs:
       actions-ref: ${{ github.sha }} # use local version
       artifact-name: dist-packages-${{ github.sha }}
       import-name: "lightning_utilities"
+      build-matrix: |
+        {
+          "os": ["ubuntu-22.04"],
+          "python-version": ["3.10"]
+        }
       testing-matrix: |
         {
           "os": ["ubuntu-22.04", "macos-12", "windows-2022"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- CI: enable setting python version for package build ([#244](https://github.com/Lightning-AI/utilities/pull/244))
 
 
 ### Deprecated


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [x] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

allowing to change python version for package building with some default

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--244.org.readthedocs.build/en/244/

<!-- readthedocs-preview lit-utilities end -->