### PR TITLE
docs: fix parsing non-trivial package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- docs: fix parsing non-trivial package name ([#247](https://github.com/Lightning-AI/utilities/pull/247))
 
 
 ## [0.11.1] - 2024-03-25

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Lightning-DevToolbox documentation
 
 .. figure:: https://pl-public-data.s3.amazonaws.com/assets_lightning/Lightning.gif
     :alt: What is Lightning gif.
-    :width: 100 %
+    :width: 80 %
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/test-page.rst
+++ b/docs/source/test-page.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+Testing page
+============
+
+This is some page serving exclusively for testing purposes.
+
+Link to scikit-learn stable documentation: https://scikit-learn.org/stable/index.html

--- a/src/lightning_utilities/docs/formatting.py
+++ b/src/lightning_utilities/docs/formatting.py
@@ -150,7 +150,7 @@ def adjust_linked_external_docs(
         return
 
     # find the expression for package version in {} brackets if any, use re to find it
-    pkg_ver_all = re.findall(r"{([\w.]+)}", target_link)
+    pkg_ver_all = re.findall(r"{(.+)}", target_link)
     for pkg_ver in pkg_ver_all:
         target_link = _update_link_based_imported_package(target_link, pkg_ver, version_digits)
 

--- a/tests/unittests/docs/test_formatting.py
+++ b/tests/unittests/docs/test_formatting.py
@@ -1,4 +1,5 @@
 import os.path
+import re
 
 import pytest
 from lightning_utilities.docs import adjust_linked_external_docs
@@ -8,25 +9,29 @@ from lightning_utilities.docs import adjust_linked_external_docs
 def test_adjust_linked_external_docs(temp_docs):
     # take config as it includes API references with `stable`
     path_conf = os.path.join(temp_docs, "conf.py")
+    path_testpage = os.path.join(temp_docs, "test-page.rst")
 
-    def _get_line_with_numpy(path_rst: str) -> str:
+    def _get_line_with_numpy(path_rst: str, pattern: str) -> str:
         with open(path_rst, encoding="UTF-8") as fopen:
             lines = fopen.readlines()
         # find the first line with figure reference
-        return next(ln for ln in lines if ln.lstrip().startswith('"numpy":'))
+        return next(ln for ln in lines if pattern in ln)
 
     # validate the initial expectations
-    line = _get_line_with_numpy(path_conf)
+    line = _get_line_with_numpy(path_conf, pattern='"numpy":')
     assert "https://numpy.org/doc/stable/" in line
+    line = _get_line_with_numpy(path_testpage, pattern="Link to scikit-learn stable documentation:")
+    assert "https://scikit-learn.org/stable/" in line
 
     adjust_linked_external_docs(
         "https://numpy.org/doc/stable/", "https://numpy.org/doc/{numpy.__version__}/", temp_docs
     )
-
-    import numpy as np
-
-    np_version = np.__version__.split(".")
+    adjust_linked_external_docs(
+        "https://scikit-learn.org/stable/", "https://scikit-learn.org/{scikit-learn}/", temp_docs
+    )
 
     # validate the final state of index page
-    line = _get_line_with_numpy(path_conf)
-    assert f"https://numpy.org/doc/{'.'.join(np_version[:2])}/" in line
+    line = _get_line_with_numpy(path_conf, pattern='"numpy":')
+    assert re.search(r"https://numpy.org/doc/([1-9]\d*)\.(\d+)/", line)
+    line = _get_line_with_numpy(path_testpage, pattern="Link to scikit-learn stable documentation:")
+    assert re.search(r"https://scikit-learn.org/([1-9]\d*)\.(\d+)/", line)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [x] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

addressing #243 when package name is not trivial
discovered in https://github.com/Lightning-AI/torchmetrics/pull/2476

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--247.org.readthedocs.build/en/247/

<!-- readthedocs-preview lit-utilities end -->