### PR TITLE
Apply func non roundtrippable seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Apply func non round-trippable seq ([#250](https://github.com/Lightning-AI/utilities/pull/250))
 
 
 ### Changed

--- a/src/lightning_utilities/core/apply_func.py
+++ b/src/lightning_utilities/core/apply_func.py
@@ -23,7 +23,7 @@ def is_dataclass_instance(obj: object) -> bool:
 def can_roundtrip_sequence(obj: Sequence) -> bool:
     """Check if sequence can be roundtripped."""
     try:
-        return obj == type(obj)(list(obj))
+        return obj == type(obj)(list(obj))  # type: ignore[call-arg]
     except (TypeError, ValueError):
         return False
 

--- a/src/lightning_utilities/core/apply_func.py
+++ b/src/lightning_utilities/core/apply_func.py
@@ -20,6 +20,14 @@ def is_dataclass_instance(obj: object) -> bool:
     return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
 
 
+def can_roundtrip_sequence(obj: Sequence) -> bool:
+    """Check if sequence can be roundtripped."""
+    try:
+        return obj == type(obj)(list(obj))
+    except (TypeError, ValueError):
+        return False
+
+
 def apply_to_collection(
     data: Any,
     dtype: Union[type, Any, Tuple[Union[type, Any]]],
@@ -118,7 +126,7 @@ def _apply_to_collection_slow(
         return elem_type(OrderedDict(out))
 
     is_namedtuple_ = is_namedtuple(data)
-    is_sequence = isinstance(data, Sequence) and not isinstance(data, str)
+    is_sequence = isinstance(data, Sequence) and not isinstance(data, str) and can_roundtrip_sequence(data)
     if is_namedtuple_ or is_sequence:
         out = []
         for d in data:

--- a/tests/unittests/core/test_apply_func.py
+++ b/tests/unittests/core/test_apply_func.py
@@ -359,3 +359,13 @@ def test_apply_to_collection_allow_frozen_dataclass():
     foo = Foo(0)
     result = apply_to_collection(foo, int, lambda x: x + 1, allow_frozen=True)
     assert foo == result
+
+
+def test_apply_to_collection_non_roundtrippable_sequence():
+    class NonRoundtrippableSequence(list):
+        def __init__(self, x: int):
+            super().__init__(range(int(x)))
+
+    val = NonRoundtrippableSequence(3)
+    result = apply_to_collection(val, int, lambda x: x + 1)
+    assert val == result


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [x] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

Fixes #249 

Note: I'm not sure if the added overhead in the slow path of apply_to_collection due to the shallow sequence copy and the elementwise comparison is undesirable to support this use case. I could reimplement this to cache the result of can_roundtrip_sequence based on the class.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


Cheers,
Andreas 😃 

<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--250.org.readthedocs.build/en/250/

<!-- readthedocs-preview lit-utilities end -->