### PR TITLE
Fix extras check in RequirementCache

### DIFF
--- a/src/lightning_utilities/__about__.py
+++ b/src/lightning_utilities/__about__.py
@@ -1,6 +1,6 @@
 import time
 
-__version__ = "0.11.4.post0"
+__version__ = "0.11.5"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/lightning_utilities/__about__.py
+++ b/src/lightning_utilities/__about__.py
@@ -1,6 +1,6 @@
 import time
 
-__version__ = "0.11.4"
+__version__ = "0.11.4.post0"
 __author__ = "Lightning AI et al."
 __author_email__ = "pytorch@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -7,8 +7,7 @@ import importlib
 import os
 import warnings
 from functools import lru_cache
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _version
+from importlib.metadata import PackageNotFoundError, distribution, version as _version
 from importlib.util import find_spec
 from types import ModuleType
 from typing import Any, Callable, List, Optional, TypeVar
@@ -128,7 +127,7 @@ class RequirementCache:
         try:
             req = Requirement(self.requirement)
             pkg_version = Version(_version(req.name))
-            self.available = req.specifier.contains(pkg_version)
+            self.available = req.specifier.contains(pkg_version) and (not req.extras or self._check_extras_available(req))
         except (PackageNotFoundError, InvalidVersion) as ex:
             self.available = False
             self.message = f"{ex.__class__.__name__}: {ex}. HINT: Try running `pip install -U {self.requirement!r}`"
@@ -143,6 +142,7 @@ class RequirementCache:
                 self.available = module_available(module)
                 if self.available:
                     self.message = f"Module {module!r} available"
+            self.message = f"Requirement {self.requirement!r} not met. HINT: Try running `pip install -U {self.requirement!r}`"
 
     def _check_module(self) -> None:
         assert self.module  # noqa: S101; needed for typing
@@ -159,6 +159,37 @@ class RequirementCache:
             self._check_requirement()
         if getattr(self, "available", True) and self.module:
             self._check_module()
+
+    def _check_extras_available(self, requirement: Requirement) -> bool:
+        if not requirement.extras:
+            return True
+
+        extra_requirements = self._get_extra_requirements(requirement)
+
+        if not extra_requirements:
+            # The specified extra is not found in the package metadata
+            return False
+
+        # Verify each extra requirement is installed
+        for extra_req in extra_requirements:
+            try:
+                extra_dist = distribution(extra_req.name)
+                extra_installed_version = Version(extra_dist.version)
+                if extra_req.specifier and not extra_req.specifier.contains(extra_installed_version):
+                    return False
+            except importlib.metadata.PackageNotFoundError:
+                return False
+
+        return True
+
+    def _get_extra_requirements(self, requirement: Requirement) -> List[Requirement]:
+        dist = distribution(requirement.name)
+        # Get the required dependencies for the specified extras
+        extra_requirements = dist.metadata.get_all('Requires-Dist') or []
+        extra_requirements = [
+            Requirement(r) for r in extra_requirements if any(extra in r for extra in requirement.extras)
+        ]
+        return extra_requirements
 
     def __bool__(self) -> bool:
         """Format as bool."""

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -191,10 +191,9 @@ class RequirementCache:
         dist = distribution(requirement.name)
         # Get the required dependencies for the specified extras
         extra_requirements = dist.metadata.get_all("Requires-Dist") or []
-        extra_requirements = [
+        return [
             Requirement(r) for r in extra_requirements if any(extra in r for extra in requirement.extras)
         ]
-        return extra_requirements
 
     def __bool__(self) -> bool:
         """Format as bool."""

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -7,7 +7,8 @@ import importlib
 import os
 import warnings
 from functools import lru_cache
-from importlib.metadata import PackageNotFoundError, distribution, version as _version
+from importlib.metadata import PackageNotFoundError, distribution
+from importlib.metadata import version as _version
 from importlib.util import find_spec
 from types import ModuleType
 from typing import Any, Callable, List, Optional, TypeVar
@@ -127,7 +128,9 @@ class RequirementCache:
         try:
             req = Requirement(self.requirement)
             pkg_version = Version(_version(req.name))
-            self.available = req.specifier.contains(pkg_version) and (not req.extras or self._check_extras_available(req))
+            self.available = req.specifier.contains(pkg_version) and (
+                not req.extras or self._check_extras_available(req)
+            )
         except (PackageNotFoundError, InvalidVersion) as ex:
             self.available = False
             self.message = f"{ex.__class__.__name__}: {ex}. HINT: Try running `pip install -U {self.requirement!r}`"
@@ -142,7 +145,9 @@ class RequirementCache:
                 self.available = module_available(module)
                 if self.available:
                     self.message = f"Module {module!r} available"
-            self.message = f"Requirement {self.requirement!r} not met. HINT: Try running `pip install -U {self.requirement!r}`"
+            self.message = (
+                f"Requirement {self.requirement!r} not met. HINT: Try running `pip install -U {self.requirement!r}`"
+            )
 
     def _check_module(self) -> None:
         assert self.module  # noqa: S101; needed for typing
@@ -185,7 +190,7 @@ class RequirementCache:
     def _get_extra_requirements(self, requirement: Requirement) -> List[Requirement]:
         dist = distribution(requirement.name)
         # Get the required dependencies for the specified extras
-        extra_requirements = dist.metadata.get_all('Requires-Dist') or []
+        extra_requirements = dist.metadata.get_all("Requires-Dist") or []
         extra_requirements = [
             Requirement(r) for r in extra_requirements if any(extra in r for extra in requirement.extras)
         ]

--- a/src/lightning_utilities/core/imports.py
+++ b/src/lightning_utilities/core/imports.py
@@ -191,9 +191,7 @@ class RequirementCache:
         dist = distribution(requirement.name)
         # Get the required dependencies for the specified extras
         extra_requirements = dist.metadata.get_all("Requires-Dist") or []
-        return [
-            Requirement(r) for r in extra_requirements if any(extra in r for extra in requirement.extras)
-        ]
+        return [Requirement(r) for r in extra_requirements if any(extra in r for extra in requirement.extras)]
 
     def __bool__(self) -> bool:
         """Format as bool."""

--- a/tests/unittests/core/test_imports.py
+++ b/tests/unittests/core/test_imports.py
@@ -1,7 +1,7 @@
 import operator
 import re
 from unittest import mock
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 
 import pytest
 from lightning_utilities.core.imports import (
@@ -82,7 +82,7 @@ def test_requirement_cache_with_extras(distribution_mock, version_mock, requirem
         get_extra_req_mock.return_value = [
             # Extra packages, all versions satisfied
             Mock(name="extra_package1", specifier=Mock(contains=Mock(return_value=True))),
-            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=True)))
+            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=True))),
         ]
         distribution_mock.return_value = Mock(version="0.10.0")
         requirement_mock().extras = ["signatures"]
@@ -92,7 +92,7 @@ def test_requirement_cache_with_extras(distribution_mock, version_mock, requirem
         get_extra_req_mock.return_value = [
             # Extra packages, but not all versions are satisfied
             Mock(name="extra_package1", specifier=Mock(contains=Mock(return_value=True))),
-            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=False)))
+            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=False))),
         ]
         distribution_mock.return_value = Mock(version="0.10.0")
         requirement_mock().extras = ["signatures"]

--- a/tests/unittests/core/test_imports.py
+++ b/tests/unittests/core/test_imports.py
@@ -1,5 +1,7 @@
 import operator
 import re
+from unittest import mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from lightning_utilities.core.imports import (
@@ -60,6 +62,41 @@ def test_requirement_cache():
     cache = RequirementCache("this_module_is_not_installed", "this_also_is_not")
     assert not cache
     assert "pip install -U 'this_module_is_not_installed" in str(cache)
+
+    cache = RequirementCache("pytest[not-valid-extra]")
+    assert not cache
+    assert "pip install -U 'pytest[not-valid-extra]" in str(cache)
+
+
+@mock.patch("lightning_utilities.core.imports.Requirement")
+@mock.patch("lightning_utilities.core.imports._version")
+@mock.patch("lightning_utilities.core.imports.distribution")
+def test_requirement_cache_with_extras(distribution_mock, version_mock, requirement_mock):
+    requirement_mock().specifier.contains.return_value = True
+    requirement_mock().name = "jsonargparse"
+    requirement_mock().extras = []
+    version_mock.return_value = "1.0.0"
+    assert RequirementCache("jsonargparse>=1.0.0")
+
+    with mock.patch("lightning_utilities.core.imports.RequirementCache._get_extra_requirements") as get_extra_req_mock:
+        get_extra_req_mock.return_value = [
+            # Extra packages, all versions satisfied
+            Mock(name="extra_package1", specifier=Mock(contains=Mock(return_value=True))),
+            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=True)))
+        ]
+        distribution_mock.return_value = Mock(version="0.10.0")
+        requirement_mock().extras = ["signatures"]
+        assert RequirementCache("jsonargparse[signatures]>=1.0.0")
+
+    with mock.patch("lightning_utilities.core.imports.RequirementCache._get_extra_requirements") as get_extra_req_mock:
+        get_extra_req_mock.return_value = [
+            # Extra packages, but not all versions are satisfied
+            Mock(name="extra_package1", specifier=Mock(contains=Mock(return_value=True))),
+            Mock(name="extra_package2", specifier=Mock(contains=Mock(return_value=False)))
+        ]
+        distribution_mock.return_value = Mock(version="0.10.0")
+        requirement_mock().extras = ["signatures"]
+        assert not RequirementCache("jsonargparse[signatures]>=1.0.0")
 
 
 def test_module_available_cache():


### PR DESCRIPTION
In #281 I made the implementation for RequirementCache to not depend on `pkg_resources`, but this accidentally broke checks against extras. For example:

```py
RequirementCache("jsonargparse[signatures]") 
```

would currently return true regardless of whether the signatures dependencies are installed or not. This is because `pkg_resources` was previously handling this directly. This PR brings this functionality back. Hopefully there are no other breakages. 

<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--283.org.readthedocs.build/en/283/

<!-- readthedocs-preview lit-utilities end -->