### PR TITLE
Pass `include-hidden-files: true` to `actions/upload-artifact`

### DIFF
--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           path: dist
+          include-hidden-files: true
 
   pkg-build:
     needs: init-store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CI: rename `import-extras` to `custom-import` in package check ([#287](https://github.com/Lightning-AI/utilities/pull/287))
+- CI: pass `include-hidden-files: true` to upload created packages ([#303](https://github.com/Lightning-AI/utilities/pull/303))
 
 ### Fixed
 


### PR DESCRIPTION
Closes #302. I referred to the last section of this migration guide: https://github.com/actions/upload-artifact/blob/b18b1d32f3f31abcdc29dee3f2484801fe7822f4/docs/MIGRATION.md

<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--303.org.readthedocs.build/en/303/

<!-- readthedocs-preview lit-utilities end -->