### PR TITLE
fix: resetting dataclass's `cached_property` once `apply_to_collection` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- fix: resetting dataclass's `cached_property` once `apply_to_collection` is called ([#363](https://github.com/Lightning-AI/utilities/pull/363))
 
 
 ---

--- a/src/lightning_utilities/core/apply_func.py
+++ b/src/lightning_utilities/core/apply_func.py
@@ -6,6 +6,7 @@ import dataclasses
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from functools import cached_property
 from typing import Any, Callable, Optional, Union
 
 
@@ -173,6 +174,12 @@ def _apply_to_collection_slow(
                 raise ValueError(
                     "A frozen dataclass was passed to `apply_to_collection` but this is not allowed."
                 ) from e
+
+        # Explicitly resetting cached property.
+        for cached_name in filter(
+            lambda k: isinstance(getattr(type(data), k), cached_property), type(data).__dict__.keys()
+        ):
+            vars(result).pop(cached_name, None)
         return result
 
     # data is neither of dtype, nor a collection

--- a/src/lightning_utilities/core/apply_func.py
+++ b/src/lightning_utilities/core/apply_func.py
@@ -177,7 +177,7 @@ def _apply_to_collection_slow(
 
         # Explicitly resetting cached property.
         for cached_name in filter(
-            lambda k: isinstance(getattr(type(data), k), cached_property), type(data).__dict__.keys()
+            lambda k: isinstance(getattr(type(data), k), cached_property), vars(type(data)).keys()
         ):
             vars(result).pop(cached_name, None)
         return result

--- a/tests/unittests/core/test_apply_func.py
+++ b/tests/unittests/core/test_apply_func.py
@@ -2,6 +2,7 @@ import dataclasses
 import numbers
 from collections import OrderedDict, defaultdict, namedtuple
 from dataclasses import InitVar
+from functools import cached_property
 from typing import Any, ClassVar, Optional
 
 import pytest
@@ -360,3 +361,19 @@ def test_apply_to_collection_allow_frozen_dataclass():
     foo = Foo(0)
     result = apply_to_collection(foo, int, lambda x: x + 1, allow_frozen=True)
     assert foo == result
+
+
+def test_apply_to_collection_with_cached_property_dataclass():
+    @dataclasses.dataclass
+    class Foo:
+        var: torch.Tensor
+
+        @cached_property
+        def cached_property(self):
+            return self.var * 2
+
+    foo = Foo(torch.tensor(1))
+    assert foo.cached_property.equal(torch.tensor(2))
+    result = apply_to_collection(foo, torch.Tensor, lambda x: x.add_(3))
+    assert result.var.equal(torch.tensor(4))
+    assert result.cached_property.equal(torch.tensor(8))

--- a/tests/unittests/core/test_apply_func.py
+++ b/tests/unittests/core/test_apply_func.py
@@ -373,7 +373,7 @@ def test_apply_to_collection_with_cached_property_dataclass():
             return self.var * 2
 
     foo = Foo(torch.tensor(1))
-    assert foo.cached_property.equal(torch.tensor(2))
+    assert torch.equal(foo.cached_property, torch.tensor(2))
     result = apply_to_collection(foo, torch.Tensor, lambda x: x.add_(3))
-    assert result.var.equal(torch.tensor(4))
-    assert result.cached_property.equal(torch.tensor(8))
+    assert torch.equal(result.var, torch.tensor(4))
+    assert torch.equal(result.cached_property, torch.tensor(8))

--- a/tests/unittests/mocks.py
+++ b/tests/unittests/mocks.py
@@ -41,6 +41,10 @@ else:
             """Perform equal operation."""
             return self.data == other
 
+        def add_(self, value):
+            self.data += value
+            return self.data
+
     class TorchMock:
         Tensor = TensorMock
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

Fixes #279 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--363.org.readthedocs.build/en/363/

<!-- readthedocs-preview lit-utilities end -->