### PR TITLE
ci: drop unused latext install for docs

### DIFF
--- a/.github/workflows/ci-use-checks.yaml
+++ b/.github/workflows/ci-use-checks.yaml
@@ -81,7 +81,7 @@ jobs:
     with:
       actions-ref: ${{ github.sha }} # use local version
       requirements-file: "requirements/_docs.txt"
-      install-tex: true
+      # install-tex: true  # todo: enable when install does not take that long
 
   check-md-links-default:
     uses: ./.github/workflows/check-md-links.yml

--- a/.github/workflows/ci-use-checks.yaml
+++ b/.github/workflows/ci-use-checks.yaml
@@ -81,7 +81,7 @@ jobs:
     with:
       actions-ref: ${{ github.sha }} # use local version
       requirements-file: "requirements/_docs.txt"
-      # install-tex: true  # todo: enable when install does not take that long
+      install-tex: true
 
   check-md-links-default:
     uses: ./.github/workflows/check-md-links.yml

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,13 +37,13 @@ jobs:
           key: pip-${{ hashFiles('requirements/*.txt') }}
           restore-keys: pip-
 
-      - name: Install texlive
-        timeout-minutes: 20
-        run: |
-          # install Texlive, see https://linuxconfig.org/how-to-install-latex-on-ubuntu-20-04-focal-fossa-linux
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y texlive-latex-extra dvipng texlive-pictures
-        shell: bash
+      #- name: Install texlive
+      #  timeout-minutes: 20
+      #  run: |
+      #    # install Texlive, see https://linuxconfig.org/how-to-install-latex-on-ubuntu-20-04-focal-fossa-linux
+      #    sudo apt-get update --fix-missing
+      #    sudo apt-get install -y texlive-latex-extra dvipng texlive-pictures
+      #  shell: bash
 
       - name: Install dependencies
         timeout-minutes: 20


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [x] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

this installations now takes 20min and it not really need
https://github.com/Lightning-AI/utilities/actions/runs/13542003974/job/37844965854?pr=363

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--365.org.readthedocs.build/en/365/

<!-- readthedocs-preview lit-utilities end -->