### PR TITLE
Fix: Update check-schema to 24.04

### DIFF
--- a/.github/workflows/check-schema.yml
+++ b/.github/workflows/check-schema.yml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   schema:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@v4


### PR DESCRIPTION
During a scheduled brownout the check-schema workflow is failing with:
```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01
```

Bumping it to latest LTS version

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->
