### PR TITLE
drop deprecated dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     pull-request-branch-name:
       separator: "-"
     open-pull-requests-limit: 5
-    reviewers:
-      - "borda"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -22,5 +20,3 @@ updates:
     pull-request-branch-name:
       separator: "-"
     open-pull-requests-limit: 5
-    reviewers:
-      - "borda"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

see deprecation warning in https://github.com/Lightning-AI/utilities/pull/401#issuecomment-2910235669

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->
