### PR TITLE
fix: correct regex in adjust to match library names at line start only

### DIFF
--- a/scripts/adjust-torch-versions.py
+++ b/scripts/adjust-torch-versions.py
@@ -140,7 +140,9 @@ def adjust(requires: list[str], pytorch_version: Optional[str] = None) -> list[s
     """Adjust the versions to be paired within pytorch ecosystem.
 
     >>> from pprint import pprint
-    >>> pprint(adjust(["torch>=1.9.0", "torchvision>=0.10.0", "torchtext>=0.10.0", "torchaudio>=0.9.0", "vmaf-torch >=1.1.0"], "2.1.0"))
+    >>> pprint(adjust([
+    ...     "torch>=1.9.0", "torchvision>=0.10.0", "torchtext>=0.10.0", "torchaudio>=0.9.0", "vmaf-torch >=1.1.0"
+    ... ], "2.1.0"))
     ['torch==2.1.0',
      'torchvision==0.16.0',
      'torchtext==0.16.0',


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

discovered in https://github.com/Lightning-AI/torchmetrics/pull/2991

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--411.org.readthedocs.build/en/411/

<!-- readthedocs-preview lit-utilities end -->