### PR TITLE
CI: make timeout configurable for install jobs in check-package.yml

### DIFF
--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -57,6 +57,11 @@ on:
           {
             "SAMPLE_ENV_VARIABLE": 1,
           }
+      timeout-minutes:
+        description: "timeout-minutes for each install job"
+        required: false
+        type: number
+        default: 30
 
 defaults:
   run:
@@ -161,7 +166,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: pypi
       - name: Installing package 📦 as Archive
-        timeout-minutes: 10
+        timeout-minutes: ${{ inputs.timeout-minutes }}
         uses: ./.cicd/.github/actions/pkg-install
         with:
           install-from: "archive"
@@ -170,7 +175,7 @@ jobs:
           import-name: ${{ inputs.import-name }}
           custom-import-code: ${{ inputs.custom-import-code }}
       - name: Installing package 📦 as Wheel
-        timeout-minutes: 10
+        timeout-minutes: ${{ inputs.timeout-minutes }}
         uses: ./.cicd/.github/actions/pkg-install
         with:
           install-from: "wheel"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

address some long installation

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--412.org.readthedocs.build/en/412/

<!-- readthedocs-preview lit-utilities end -->