### PR TITLE
Replace deprecated MacOS 13 runner

### DIFF
--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -46,7 +46,7 @@ on:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         default: |
           {
-            "os": ["ubuntu-22.04", "macos-13", "windows-2022"],
+            "os": ["ubuntu-22.04", "macos-latest", "windows-2022"],
             "python-version": ["3.9", "3.13"]
           }
       env-vars:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-13", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-latest", "windows-2022"]
         python-version: ["3.9", "3.11", "3.13"]
         requires: ["oldest", "latest"]
         exclude:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- Did you make sure to update the docs?
- [ ] Did all existing and newly added tests pass locally?

</details>

## What does this PR do?

[`macos-13` runner is deprecated](https://github.com/actions/runner-images/issues/13046). Update instances of `macos-13` to use `macos-latest` instead.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->


<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--446.org.readthedocs.build/en/446/

<!-- readthedocs-preview lit-utilities end -->