### PR TITLE
ci: add 2-day package install cooldown (supply-chain guard)

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -58,6 +58,8 @@ env:
   UV_TORCH_BACKEND: cpu
   # default 0 means to keep for the maximum time
   KEEP_DAYS: 0
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
 
 jobs:
   make-docs:

--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -68,6 +68,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   pkg-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check-precommit.yml
+++ b/.github/workflows/check-precommit.yml
@@ -27,6 +27,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check-schema.yml
+++ b/.github/workflows/check-schema.yml
@@ -23,6 +23,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   schema:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-typing.yml
+++ b/.github/workflows/check-typing.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       UV_TORCH_BACKEND: cpu
+      # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
@@ -50,8 +52,11 @@ jobs:
         timeout-minutes: 20
         run: |
           # don't use --upgrade to respect the version installed via setup.py
+          # `unsafe-best-match` required: PyTorch extra-index mirrors older packages that
+          # conflict with version ranges under UV_EXCLUDE_NEWER without fallback to PyPI.
           uv pip install -e '.[${{ inputs.extra-typing }}]' mypy types-requests \
-            --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html
+            --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html \
+            --index-strategy unsafe-best-match
           uv pip list
 
       - name: Pull reusable 🤖 actions️

--- a/.github/workflows/check-typing.yml
+++ b/.github/workflows/check-typing.yml
@@ -52,11 +52,8 @@ jobs:
         timeout-minutes: 20
         run: |
           # don't use --upgrade to respect the version installed via setup.py
-          # `unsafe-best-match` required: PyTorch extra-index mirrors older packages that
-          # conflict with version ranges under UV_EXCLUDE_NEWER without fallback to PyPI.
           uv pip install -e '.[${{ inputs.extra-typing }}]' mypy types-requests \
-            --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html \
-            --index-strategy unsafe-best-match
+            --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html
           uv pip list
 
       - name: Pull reusable 🤖 actions️

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -10,6 +10,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   test-cli:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -10,6 +10,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   test-scripts:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -26,6 +26,8 @@ jobs:
     env:
       TORCH_URL: "https://download.pytorch.org/whl/cpu/torch_stable.html"
       UV_TORCH_BACKEND: cpu
+      # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@v6

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -37,6 +37,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       AGE_DAYS: ${{ inputs.age-days }}
+      # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,6 +16,8 @@ jobs:
     env:
       TORCH_URL: "https://download.pytorch.org/whl/cpu/torch_stable.html"
       UV_TORCH_BACKEND: cpu
+      # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -14,6 +14,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
+
 jobs:
   # based on https://github.com/pypa/gh-action-pypi-publish
   build-package:


### PR DESCRIPTION
## What does this PR do?

Adds a CI-only supply-chain guard: the resolver refuses any PyPI release published within the last **2 days**, so typosquats and malicious uploads that get yanked within ~24 h never land in our CI environment.

### How it's wired

All workflows in this repo are uv-based, so the guard is applied uniformly via:

| Env var | Value | Scope |
|---|---|---|
| `UV_EXCLUDE_NEWER` | `"2 days"` | All 11 uv-based workflows |

Reference: Lightning-AI/pytorch-lightning#21722

<!-- readthedocs-preview lit-utilities start -->
----
📚 Documentation preview 📚: https://lit-utilities--494.org.readthedocs.build/en/494/

<!-- readthedocs-preview lit-utilities end -->