### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
 
     - name: Cache 💽 pip
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: ${{ steps.cache_dirs.outputs.pip_dir }}
         key: py${{ inputs.python-version }}-pip-${{ inputs.offset }}-${{ hashFiles('requirements.txt') }}
@@ -35,7 +35,7 @@ runs:
         enableCrossOsArchive: true
 
     - name: Cache 💽 conda
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       if: runner.os == 'Linux'
       with:
         path: ~/conda_pkgs_dir

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
 
     - name: Cache 💽 pip
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.cache_dirs.outputs.pip_dir }}
         key: py${{ inputs.python-version }}-pip-${{ inputs.offset }}-${{ hashFiles('requirements.txt') }}
@@ -35,7 +35,7 @@ runs:
         enableCrossOsArchive: true
 
     - name: Cache 💽 conda
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: runner.os == 'Linux'
       with:
         path: ~/conda_pkgs_dir

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -71,12 +71,12 @@ jobs:
         target: ${{ fromJSON(inputs.make-target) }}
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
       - name: Set up uv and Python 🐍 ${{ inputs.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ inputs.python-version }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Pull reusable 🤖 actions️
         if: ${{ inputs.actions-ref != '' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd
@@ -121,7 +121,7 @@ jobs:
         if: startsWith(github.event_name, 'pull_request')
         run: echo "KEEP_DAYS=7" >> $GITHUB_ENV
       - name: Upload built docs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-${{ matrix.target }}-${{ github.sha }}
           path: ${{ inputs.docs-dir }}/build/

--- a/.github/workflows/check-md-links.yml
+++ b/.github/workflows/check-md-links.yml
@@ -28,7 +28,7 @@ jobs:
       MODIFIED_ONLY: "no"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create local version of config
         if: ${{ inputs.config-file == '' }}
@@ -63,7 +63,7 @@ jobs:
         run: echo "MODIFIED_ONLY=yes" >> $GITHUB_ENV
 
       - name: Checking markdown link
-        uses: tcort/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:
           base-branch: ${{ inputs.base-branch }}
           use-quiet-mode: "yes"

--- a/.github/workflows/check-package.yml
+++ b/.github/workflows/check-package.yml
@@ -81,19 +81,19 @@ jobs:
       matrix: ${{ fromJSON(inputs.build-matrix) }}
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # checkout entire history for all branches (required when using scm-based versioning)
           submodules: recursive
       - name: Set up uv and Python 🐍
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version || '3.x' }}
           enable-cache: true
 
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd
@@ -106,7 +106,7 @@ jobs:
         uses: ./.cicd/.github/actions/pkg-create
       - name: Upload 📤 packages
         if: ${{ inputs.artifact-name != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}-build-${{ strategy.job-index }}
           path: dist
@@ -119,13 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd
           repository: Lightning-AI/utilities
       - name: Set up uv and Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"
@@ -136,7 +136,7 @@ jobs:
           uv pip list
 
       - name: Download 📥
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # download all build artifacts
           pattern: ${{ inputs.artifact-name }}-build-*
@@ -147,7 +147,7 @@ jobs:
           ls -lh dist/
           twine check dist/*
       - name: Upload 📤
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: dist
@@ -164,24 +164,24 @@ jobs:
       matrix: ${{ fromJSON(inputs.testing-matrix) }}
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       # NOTE: use pip as gold standard for package validation
       - name: Set up Python 🐍 ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version || '3.x' }}
 
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd
           repository: Lightning-AI/utilities
       - name: Download 📥 all packages
         if: ${{ inputs.artifact-name != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: pypi

--- a/.github/workflows/check-precommit.yml
+++ b/.github/workflows/check-precommit.yml
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.github-token || github.token }}
 
       - name: Set up uv and Python 🐍
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ inputs.python-version }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache 💽 pre-commit
         if: ${{ inputs.use-cache == true }}
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|py${{ inputs.python-version }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Fixing Pull Request ↩️
         if: always() && inputs.push-fixes == true && steps.precommit.outcome == 'failure'
-        uses: actions-js/push@v1.5
+        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
         with:
           github_token: ${{ secrets.github-token || github.token }}
           message: "pre-commit: running and fixing..."

--- a/.github/workflows/check-ruff.yml
+++ b/.github/workflows/check-ruff.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Ruff 🐍
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           version: ${{ inputs.ruff-version }}
           args: "check --output-format=github"

--- a/.github/workflows/check-schema.yml
+++ b/.github/workflows/check-schema.yml
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: Set up uv and Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"
@@ -45,7 +45,7 @@ jobs:
       # if actions version is given install defined versions
       - name: "[optional] Pull reusable 🤖 actions"
         if: inputs.actions-ref != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd

--- a/.github/workflows/check-typing.yml
+++ b/.github/workflows/check-typing.yml
@@ -37,12 +37,12 @@ jobs:
       UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
       - name: Set up uv and Python 🐍 ${{ inputs.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ inputs.python-version }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Pull reusable 🤖 actions️
         if: ${{ inputs.actions-ref != '' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.actions-ref }}
           path: .cicd

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up uv and Python 🐍 ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up uv and Python 🐍 ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}
@@ -55,9 +55,9 @@ jobs:
       UV_TORCH_BACKEND: cpu
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up uv and Python 🐍 ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -30,11 +30,11 @@ jobs:
       UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: Set up uv and Python 🐍 ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}
@@ -69,7 +69,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -41,17 +41,17 @@ jobs:
       UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up uv and Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"
           enable-cache: true
 
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.scripts-ref }}
           path: .cicd

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,13 +20,13 @@ jobs:
       UV_EXCLUDE_NEWER: "2 days"
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
-        # If you're using actions/checkout@v6 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        # If you're using actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
           persist-credentials: false
           submodules: recursive
       - name: Set up uv and Python 🐍
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"
@@ -53,7 +53,7 @@ jobs:
         run: make html --jobs 2
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         if: github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up uv and Python 🐍
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.10"
@@ -37,7 +37,7 @@ jobs:
       - name: Create 📦 package
         uses: ./.github/actions/pkg-create
       - name: Upload 📤 packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download 📥 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -62,7 +62,7 @@ jobs:
         run: ls -lh dist/
 
       - name: Upload to release
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
         with:
           files: "dist/*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,11 +74,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: Download 📥 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -87,7 +87,7 @@ jobs:
 
       # We do this, since failures on test.pypi aren't that bad
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
@@ -95,7 +95,7 @@ jobs:
           verbose: true
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## What does this PR do?

Pins GitHub Actions to verified commit SHAs for supply chain security.

This follows the same pattern as https://github.com/Lightning-AI/pytorch-lightning/pull/21735.

Also incorporates version bumps from open Dependabot PRs, so those can be closed.

## Pinned references

| Action / workflow | Release | Commit SHA |
| --- | --- | --- |
| actions/checkout | [v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0) | 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 |
| actions/setup-python | [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0) | a309ff8b426b58ec0e2a45f0f869d46889d02405 |
| actions/upload-artifact | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a |
| actions/download-artifact | [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1) | 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c |
| actions/cache | [v5.0.5](https://github.com/actions/cache/releases/tag/v5.0.5) | 27d5ce7f107fe9357f9df03efb73ab90386fccae |
| astral-sh/setup-uv | [v7.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0) | 37802adc94f370d6bfd71619e3f0bf239e1f3b78 |
| astral-sh/ruff-action | [v3.6.1](https://github.com/astral-sh/ruff-action/releases/tag/v3.6.1) | 4919ec5cf1f49eff0871dbcea0da843445b837e6 |
| actions-js/push | [v1.5](https://github.com/actions-js/push/releases/tag/v1.5) | 5a7cbd780d82c0c937b5977586e641b2fd94acc5 |
| JamesIves/github-pages-deploy-action | [v4.8.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.8.0) | d92aa235d04922e8f08b40ce78cc5442fcfbfa2f |
| tcort/github-action-markdown-link-check | [v1.1.2](https://github.com/tcort/github-action-markdown-link-check/releases/tag/v1.1.2) | e7c7a18363c842693fadde5d41a3bd3573a7a225 |
| codecov/codecov-action | [v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0) | fb8b3582c8e4def4969c97caa2f19720cb33a72f |
| AButler/upload-release-assets | [v4.0.0](https://github.com/AButler/upload-release-assets/releases/tag/v4.0.0) | 34491005a5d7ec239a784e460807ce844fde7962 |
| pypa/gh-action-pypi-publish | [v1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0) | cef221092ed1bacb1cc03d23a2d87d1d172e277b |

Closes #497
Closes #496
Closes #489
Closes #486